### PR TITLE
Cookiebanner

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-gtm-module": "^2.0.11",
     "react-mailchimp-subscribe": "^2.1.3",
     "react-scripts": "4.0.3",
-    "sass": "^1.42.1"
+    "sass": "^1.42.1",
+    "universal-cookie": "^4.0.4"
   },
   "scripts": {
     "start": "node server.js",

--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,30 @@
-import React from "react";
+import React, { useEffect } from "react";
 import "./styling/App.scss";
 import Header from "./components/Header/Header";
 import LandingPage from "./pages/LandingPage";
 import Modal from "./components/Modal/Modal";
 import TagManager from "react-gtm-module";
 import { useState } from "react";
+import Cookies from 'universal-cookie';
+
+const cookies = new Cookies();
 
 const tagManagerArgs = {
   gtmId: "GTM-M628J8Q",
 };
 
-TagManager.initialize(tagManagerArgs);
 
 function App() {
+
+  useEffect(() => {
+    console.log("GTM CHECK")
+    if(cookies.get('cookie-consent') === "true") {
+      console.log("accepted")
+      TagManager.initialize(tagManagerArgs);
+    } else {
+      console.log("denied/unset")
+    }
+  }, [])
   const [showModal, setShowModal] = useState(false);
   const [modalData, setModalData] = useState({ type: null, key: null });
   const toggleModal = () => {

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import "./styling/App.scss";
 import Header from "./components/Header/Header";
 import LandingPage from "./pages/LandingPage";
+import CookieBanner from "./components/Banner/CookieBanner"
 import Modal from "./components/Modal/Modal";
 import TagManager from "react-gtm-module";
 import { useState } from "react";
@@ -41,6 +42,7 @@ function App() {
       <Header />
       <LandingPage setModal={setModal} />
       {showModal && <Modal data={modalData} toggleModal={toggleModal} />}
+      <CookieBanner />
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -16,18 +16,19 @@ const tagManagerArgs = {
 
 
 function App() {
-
-  useEffect(() => {
-    console.log("GTM CHECK")
-    if(cookies.get('cookie-consent') === "true") {
-      console.log("accepted")
-      TagManager.initialize(tagManagerArgs);
-    } else {
-      console.log("denied/unset")
-    }
-  }, [])
   const [showModal, setShowModal] = useState(false);
   const [modalData, setModalData] = useState({ type: null, key: null });
+  const [showCBanner, setShowCBanner] = useState(() => {
+    return !cookies.get('cookie-consent')
+  })
+
+  useEffect(() => {
+    if(cookies.get('cookie-consent') === "true") {
+      TagManager.initialize(tagManagerArgs);
+    }
+  }, [showCBanner])
+
+
   const toggleModal = () => {
     setShowModal((prevState) => !prevState);
   };
@@ -37,12 +38,17 @@ function App() {
     toggleModal();
   };
 
+  const handleCookieBanner = (arg) => {
+    setShowCBanner(false)
+    cookies.set('cookie-consent', arg)
+  }
+
   return (
     <div className="App">
       <Header />
       <LandingPage setModal={setModal} />
       {showModal && <Modal data={modalData} toggleModal={toggleModal} />}
-      <CookieBanner />
+      {showCBanner && <CookieBanner cookies={cookies} handleBanner={handleCookieBanner}/>}
     </div>
   );
 }

--- a/src/components/Banner/CookieBanner.js
+++ b/src/components/Banner/CookieBanner.js
@@ -1,0 +1,11 @@
+import "./cookieBanner.scss";
+
+const CookieBanner = () => {
+  return (
+    <div className="cookiebanner">
+      <p>COKKIE???</p>
+    </div>
+  );
+};
+
+export default CookieBanner;

--- a/src/components/Banner/CookieBanner.js
+++ b/src/components/Banner/CookieBanner.js
@@ -5,8 +5,10 @@ const CookieBanner = ({handleBanner}) => {
   return (
     <div className="cookiebanner">
       <p>Want some cookies? We use cookies to ensure that we give you the best experience on our website, Please let us know if you agree to our cookies.</p>
-      <Button onClick={() => handleBanner("false")} color="mint">I dont want cookies</Button>
-      <Button onClick={() => handleBanner("true")} color="lavender">Accept & continue</Button>
+      <div className="cookie-buttons">
+        <Button onClick={() => handleBanner("false")} color="mint">I dont want cookies</Button>
+        <Button onClick={() => handleBanner("true")} color="lavender">Accept & continue</Button>
+      </div>
     </div>
   );
 };

--- a/src/components/Banner/CookieBanner.js
+++ b/src/components/Banner/CookieBanner.js
@@ -1,9 +1,12 @@
+import Button from "../Button/Button";
 import "./cookieBanner.scss";
 
-const CookieBanner = () => {
+const CookieBanner = ({cookies}) => {
   return (
     <div className="cookiebanner">
-      <p>COKKIE???</p>
+      <p>Want some cookies? We use cookies to ensure that we give you the best experience on our website, Please let us know if you agree to our cookies.</p>
+      <Button color="mint">I dont want cookies</Button>
+      <Button color="lavender">Accept & continue</Button>
     </div>
   );
 };

--- a/src/components/Banner/CookieBanner.js
+++ b/src/components/Banner/CookieBanner.js
@@ -1,12 +1,12 @@
 import Button from "../Button/Button";
 import "./cookieBanner.scss";
 
-const CookieBanner = ({cookies}) => {
+const CookieBanner = ({handleBanner}) => {
   return (
     <div className="cookiebanner">
       <p>Want some cookies? We use cookies to ensure that we give you the best experience on our website, Please let us know if you agree to our cookies.</p>
-      <Button color="mint">I dont want cookies</Button>
-      <Button color="lavender">Accept & continue</Button>
+      <Button onClick={() => handleBanner("false")} color="mint">I dont want cookies</Button>
+      <Button onClick={() => handleBanner("true")} color="lavender">Accept & continue</Button>
     </div>
   );
 };

--- a/src/components/Banner/cookieBanner.scss
+++ b/src/components/Banner/cookieBanner.scss
@@ -6,4 +6,6 @@
   bottom: 0;
   left: 0;
   width: 100vw;
+  display: flex;
+  align-items: center;
 }

--- a/src/components/Banner/cookieBanner.scss
+++ b/src/components/Banner/cookieBanner.scss
@@ -12,6 +12,7 @@
 
   p {
     margin: 0;
+    color: white;
   }
 }
 

--- a/src/components/Banner/cookieBanner.scss
+++ b/src/components/Banner/cookieBanner.scss
@@ -5,7 +5,28 @@
   position: fixed;
   bottom: 0;
   left: 0;
-  width: 100vw;
-  display: flex;
+  width: 100%;
   align-items: center;
+  padding: 1rem;
+  box-sizing: border-box;
+
+  p {
+    margin: 0;
+  }
+}
+
+.cookie-buttons {
+  display: flex;
+}
+
+@media screen and (min-width: 768px) {
+  .cookiebanner {
+    display: flex;
+  }
+}
+
+@media screen and (min-width: 992px) {
+  .cookiebanner {
+    display: flex;
+  }
 }

--- a/src/components/Banner/cookieBanner.scss
+++ b/src/components/Banner/cookieBanner.scss
@@ -1,0 +1,9 @@
+@import "../../styling/components/_colors.scss";
+
+.cookiebanner {
+  background-color: $mint;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100vw;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,6 +1787,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
 "@types/eslint@^7.28.2":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.29.0.tgz#e56ddc8e542815272720bb0b4ccc2aff9c3e1c78"
@@ -3512,6 +3517,11 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookie@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -10728,6 +10738,14 @@ unique-string@^1.0.0:
   integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
   dependencies:
     crypto-random-string "^1.0.0"
+
+universal-cookie@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
+  integrity sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==
+  dependencies:
+    "@types/cookie" "^0.3.3"
+    cookie "^0.4.0"
 
 universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Pull Request

#### Notion Link
- [Notion Link]()

### Issues Ref
- #51 

### Assigned Devs
- @valentinLW 

### Changes and Updates
- displays cookie banner and only initializes gtm when user accepts

### Added APIs, Webpack or Yarn/NPM installs
- universal-cookie npm package

### Notes
- _No new notes_
